### PR TITLE
Updated display font for Calibri to display correctly in Typography section.

### DIFF
--- a/ux/demos/typography/typefaces.html
+++ b/ux/demos/typography/typefaces.html
@@ -48,7 +48,7 @@
       padding-bottom: 0;
     }
 
-    .demo-wrapper-di .stimulus-paragraph {
+    .calibri {
       font-family: Calibri, Arial, sans-serif;
       font-size: 24px;
       line-height: 1.11;
@@ -68,9 +68,9 @@
 <body>
 
   <div class="demo-wrapper demo-wrapper-di">
-    <div class="demo-label">Calibri</div>
+    <div class="demo-label calibri">Calibri</div>
     <div class="type-demo">
-      <div class="stimulus-paragraph">
+      <div class="stimulus-paragraph calibri">
         <p>Aa Bb Cc Dd Ee Ff Gg Hh Ii Jj Kk Ll Mm Nn Oo Pp Qq Rr Ss Tt Uu Vv Ww</p>
       </div>
     </div>


### PR DESCRIPTION
Before:
![current_font_rendering](https://user-images.githubusercontent.com/44465/98390122-cf523d80-2009-11eb-9c11-fcf25898f016.png)
After:
![rendering_with_calibri](https://user-images.githubusercontent.com/44465/98390138-d2e5c480-2009-11eb-86f3-823392e51024.png)

Display font in Typography section with Calibri example incorrectly uses Clear Sans. This is a minor change that uses the correct display font.